### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lein-test.yaml
+++ b/.github/workflows/lein-test.yaml
@@ -1,5 +1,7 @@
 ---
 name: lein_test
+permissions:
+  contents: read
 
 on:
   pull_request: {}


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVoxProject/clj-parent/security/code-scanning/1](https://github.com/OpenVoxProject/clj-parent/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for most CI workflows that only need to read repository contents. This change ensures that the `GITHUB_TOKEN` has minimal permissions, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
