### PR TITLE
Remove unused puppetlabs/host-action-collector-client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -105,7 +105,6 @@
                          [prismatic/schema "1.1.12"]
                          [stylefruits/gniazdo "1.2.1"]
 
-                         [puppetlabs/host-action-collector-client "0.1.8"]
                          [puppetlabs/http-client "2.1.3"]
                          [puppetlabs/jdbc-util "1.4.3"]
                          [puppetlabs/typesafe-config "0.2.0"]


### PR DESCRIPTION
This project isn't published on clojars.org (anymore?) and it's only used for PE services, so we can remove it.