### PR TITLE
bump version to -snapshot after release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def rbac-client-version "1.1.5")
 (def dropwizard-metrics-version "3.2.2")
 
-(defproject org.openvoxproject/clj-parent "7.4.0"
+(defproject org.openvoxproject/clj-parent "7.4.0-snapshot"
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.


### PR DESCRIPTION
This seems to be a common pattern for Java / Clojure