### PR TITLE
remove unused puppetlabs/cljs-dashboard-widgets

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -128,7 +128,6 @@
                          [puppetlabs/comidi "1.0.0"]
                          [puppetlabs/trapperkeeper-comidi-metrics "0.1.1"]
                          [puppetlabs/i18n "0.9.2"]
-                         [puppetlabs/cljs-dashboard-widgets "0.1.0"]
                          [puppetlabs/rbac-client ~rbac-client-version]
                          [puppetlabs/rbac-client ~rbac-client-version :classifier "test"]
                          [puppetlabs/clj-shell-utils "2.0.1"]


### PR DESCRIPTION
from https://github.com/puppetlabs-toy-chest/cljs-dashboard-widgets

> This repository was archived by the owner on Sep 4, 2019. It is now read-only.